### PR TITLE
feat: respect CODEX_DEFAULT_MODEL env var in tool descriptions

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,18 @@ export const AVAILABLE_CODEX_MODELS = [
 
 // Helper function to generate model description
 export const getModelDescription = (toolType: 'codex' | 'review') => {
+  const envModel = process.env[CODEX_DEFAULT_MODEL_ENV_VAR];
+  const defaultModel = envModel || DEFAULT_CODEX_MODEL;
+
+  if (envModel) {
+    // When env var is set, don't show hardcoded model list (it may be outdated)
+    if (toolType === 'codex') {
+      return `Specify which model to use (defaults to ${defaultModel})`;
+    }
+    return `Specify which model to use for the review (defaults to ${defaultModel})`;
+  }
+
+  // Fallback to original behavior with model list
   const modelList = AVAILABLE_CODEX_MODELS.join(', ');
   if (toolType === 'codex') {
     return `Specify which model to use (defaults to ${DEFAULT_CODEX_MODEL}). Options: ${modelList}`;


### PR DESCRIPTION
## Problem

When using this MCP server with AI agents (like Claude), the agent sees the hardcoded model list in tool descriptions:

```
Specify which model to use (defaults to gpt-5.3-codex). Options: gpt-5.3-codex, gpt-5.2-codex, ...
```

This causes issues because:
1. The model list becomes outdated as OpenAI releases new models
2. AI agents may try to use outdated model names from this list
3. Even with `CODEX_DEFAULT_MODEL` env var set, the description still shows the old list

## Solution

When `CODEX_DEFAULT_MODEL` environment variable is set:
- Use the env var value as default model in tool descriptions
- Hide the hardcoded model list (which may become outdated)

This way, users who set `CODEX_DEFAULT_MODEL` get clean descriptions without outdated model names.

## Changes

- Modified `getModelDescription()` in `src/types.ts` to read the env var
- Backward compatible: original behavior preserved when env var is not set

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactoring**
  * Model selection descriptions now support environment-based configuration. When enabled, descriptions provide simplified guidance for model selection. When not configured, comprehensive model listings display as before, ensuring full backward compatibility with existing setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->