### PR TITLE
chore(ci): switch npm publish to OIDC Trusted Publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,8 +108,7 @@ jobs:
       - name: Publish to npm
         if: steps.tag.outputs.new_tag != ''
         run: npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        # Auth via OIDC Trusted Publishing — no NPM_TOKEN secret needed
 
       - name: Upload build artifacts
         if: steps.tag.outputs.new_tag != ''


### PR DESCRIPTION
## Summary

Remove `NODE_AUTH_TOKEN` secret dependency from the publish step. npm will authenticate via OIDC using the existing `id-token: write` permission, eliminating the need to store and rotate an `NPM_TOKEN` secret.

## Change

```diff
-      - name: Publish to npm
-        run: npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Publish to npm
+        run: npm publish --access public --provenance
+        # Auth via OIDC Trusted Publishing — no NPM_TOKEN secret needed
```

## Before merging

Configure Trusted Publishing on npmjs.com:

1. Go to the package page → Settings → Publishing Access
2. Trusted Publishers → Add Publisher → GitHub Actions
3. Fill in:
   - Repository Owner: tuannvm
   - Repository: codex-mcp-server
   - Workflow Filename: release.yml

## Benefits

- No long-lived NPM_TOKEN secret to store or rotate
- Provenance badges on npm package page
- Stronger supply chain security

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release publication process configuration to improve security and streamline the publishing workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->