### PR TITLE
fix: route review through codex exec

### DIFF
--- a/src/__tests__/working-directory.test.ts
+++ b/src/__tests__/working-directory.test.ts
@@ -44,15 +44,19 @@ describe('Working Directory (cwd) Support', () => {
         workingDirectory: '/path/to/worktree',
       });
 
-      // Should pass -C flag in args AND cwd in options
+      // Review must run through exec so -C and --skip-git-repo-check are exec flags.
       expect(mockedExecuteCommand).toHaveBeenCalledWith(
         'codex',
-        expect.arrayContaining([
+        [
+          'exec',
+          '--model',
+          'gpt-5.3-codex',
           '-C',
           '/path/to/worktree',
+          '--skip-git-repo-check',
           'review',
           '--uncommitted',
-        ]),
+        ],
         expect.objectContaining({ cwd: '/path/to/worktree' })
       );
     });
@@ -64,7 +68,14 @@ describe('Working Directory (cwd) Support', () => {
 
       expect(mockedExecuteCommand).toHaveBeenCalledWith(
         'codex',
-        expect.arrayContaining(['review', '--uncommitted']),
+        [
+          'exec',
+          '--model',
+          'gpt-5.3-codex',
+          '--skip-git-repo-check',
+          'review',
+          '--uncommitted',
+        ],
         expect.objectContaining({ cwd: undefined })
       );
     });
@@ -83,7 +94,16 @@ describe('Working Directory (cwd) Support', () => {
 
       expect(mockedExecuteCommandStreaming).toHaveBeenCalledWith(
         'codex',
-        expect.arrayContaining(['-C', '/path/to/worktree']),
+        [
+          'exec',
+          '--model',
+          'gpt-5.3-codex',
+          '-C',
+          '/path/to/worktree',
+          '--skip-git-repo-check',
+          'review',
+          '--uncommitted',
+        ],
         expect.objectContaining({ cwd: '/path/to/worktree' })
       );
     });

--- a/src/tools/handlers.ts
+++ b/src/tools/handlers.ts
@@ -406,20 +406,21 @@ export class ReviewToolHandler {
         ? path.resolve(workingDirectory)
         : undefined;
 
-      // Build command arguments for codex review
-      const cmdArgs: string[] = [];
+      // Run review through exec so working directory and trust flags are honored.
+      const cmdArgs: string[] = ['exec'];
+
+      // Add model parameter
+      const selectedModel =
+        model ||
+        process.env[CODEX_DEFAULT_MODEL_ENV_VAR] ||
+        DEFAULT_CODEX_MODEL;
+      cmdArgs.push('--model', selectedModel);
 
       if (resolvedWorkDir) {
         cmdArgs.push('-C', resolvedWorkDir);
       }
 
-      // Add model parameter via config
-      const selectedModel =
-        model ||
-        process.env[CODEX_DEFAULT_MODEL_ENV_VAR] ||
-        DEFAULT_CODEX_MODEL;
-      cmdArgs.push('-c', `model="${selectedModel}"`);
-
+      cmdArgs.push('--skip-git-repo-check');
       cmdArgs.push('review');
 
       // Add review-specific flags


### PR DESCRIPTION
## Summary
- run the review tool through `codex exec ... review` so exec flags apply
- pass `--model`, optional `-C`, and `--skip-git-repo-check` before the `review` subcommand
- tighten working-directory tests to assert the full argument order

Fixes #124. This intentionally avoids the stale approach from #191, where `--skip-git-repo-check` was added to direct `codex review`; the flag belongs to `codex exec`.

## Testing
- `npm run build`
- `npm test -- --runInBand src/__tests__/working-directory.test.ts`
- `npm test -- --runInBand`
- `npm run lint`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how code reviews are launched so they work more reliably from a specified working directory.
  * Review commands now handle repository context more consistently, reducing failures when running outside a git root.
  * Updated command execution behavior to better match the expected review flow in both standard and streaming runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->