### PR TITLE
feat: add GPT-5.6 models, default to gpt-5.6-sol

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,7 +120,7 @@ Note: Config flags (`-c`) must come BEFORE the subcommand (`exec` or `resume`).
 
 ### Environment Variables
 
-- `CODEX_DEFAULT_MODEL`: Default model for codex/review tools (default: `gpt-5.3-codex`)
+- `CODEX_DEFAULT_MODEL`: Default model for codex/review tools (default: `gpt-5.6-sol`)
 - `CODEX_MCP_CALLBACK_URI`: Static MCP callback URI passed to Codex (override via tool arg)
 - `STRUCTURED_CONTENT_ENABLED`: Enable `structuredContent` in responses (default: false)
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -101,7 +101,7 @@ Execute Codex CLI with advanced session management and model control.
 | `prompt` | string | ✅ | - | The coding task, question, or analysis request |
 | `sessionId` | string | ❌ | - | Session ID for conversational context |
 | `resetSession` | boolean | ❌ | `false` | Reset session history before processing |
-| `model` | string | ❌ | `gpt-5.2-codex` | Model to use for processing |
+| `model` | string | ❌ | `gpt-5.6-sol` | Model to use for processing |
 | `reasoningEffort` | enum | ❌ | - | Control reasoning depth |
 | `sandbox` | enum | ❌ | - | Sandbox policy: `read-only`, `workspace-write`, `danger-full-access` |
 | `fullAuto` | boolean | ❌ | `false` | Enable full-auto mode (sandboxed automatic execution) |
@@ -109,8 +109,13 @@ Execute Codex CLI with advanced session management and model control.
 | `callbackUri` | string | ❌ | - | Static MCP callback URI passed via env to Codex |
 
 #### Model Options
-- `gpt-5.2-codex` (default) - Latest specialized coding model optimized for agentic tasks
-- `gpt-5.1-codex` - Previous coding model version
+- `gpt-5.6-sol` (default) - GPT-5.6 flagship, quality-first reasoning and difficult coding
+- `gpt-5.6-terra` - Balanced quality, latency, and cost for everyday tasks
+- `gpt-5.6-luna` - High-throughput, lower-latency work
+- `gpt-5.6` - GPT-5.6 family alias (routes to Sol)
+- `gpt-5.3-codex` - Previous specialized coding model
+- `gpt-5.2-codex` - Earlier coding model version
+- `gpt-5.1-codex` - Earlier coding model version
 - `gpt-5.1-codex-max` - Enhanced coding model for complex tasks
 - `gpt-5-codex` - Base GPT-5 coding model
 - `gpt-4o` - Fast multimodal model
@@ -208,7 +213,7 @@ Run AI-powered code reviews against your repository using Codex CLI.
 | `base` | string | ❌ | - | Review changes against a specific base branch |
 | `commit` | string | ❌ | - | Review changes introduced by a specific commit SHA |
 | `title` | string | ❌ | - | Title to display in the review summary |
-| `model` | string | ❌ | `gpt-5.2-codex` | Model to use for the review (passed via `-c model="..."`) |
+| `model` | string | ❌ | `gpt-5.6-sol` | Model to use for the review (passed via `-c model="..."`) |
 | `workingDirectory` | string | ❌ | - | Working directory to run the review in (passed via `-C`) |
 
 #### Examples
@@ -414,7 +419,7 @@ interface ErrorResponse {
 - **Context Optimization**: Recent turns only (last 2) for fallback context
 
 ### Response Optimization
-- **Model Selection**: Default `gpt-5.2-codex` optimized for agentic coding
+- **Model Selection**: Default `gpt-5.6-sol` optimized for agentic coding
 - **Reasoning Control**: Adjust effort based on task complexity
 - **Native Resume**: Preferred over manual context building
 

--- a/docs/codex-cli-integration.md
+++ b/docs/codex-cli-integration.md
@@ -71,11 +71,16 @@ This MCP server is optimized for **codex CLI v0.75.0 or later** for full feature
 - **MCP Parameter**: `workingDirectory` parameter in codex tool and review tool
 
 ### 5. Model Selection
-- **Default Model**: `gpt-5.2-codex` (optimal for agentic coding tasks)
+- **Default Model**: `gpt-5.6-sol` (GPT-5.6 flagship, optimal for agentic coding tasks)
 - **CLI Flag**: `--model <model-name>`
 - **Supported Models**:
-  - `gpt-5.2-codex` (default, specialized for agentic coding)
-  - `gpt-5.1-codex` (previous coding model)
+  - `gpt-5.6-sol` (default, GPT-5.6 flagship for reasoning and difficult coding)
+  - `gpt-5.6-terra` (balanced quality, latency, and cost)
+  - `gpt-5.6-luna` (high-throughput, lower-latency)
+  - `gpt-5.6` (family alias, routes to Sol)
+  - `gpt-5.3-codex` (previous coding model)
+  - `gpt-5.2-codex` (earlier coding model)
+  - `gpt-5.1-codex` (earlier coding model)
   - `gpt-5.1-codex-max` (enhanced coding)
   - `gpt-5-codex` (base GPT-5 coding)
   - `gpt-4o` (fast multimodal)
@@ -259,7 +264,7 @@ if (conversationIdMatch) {
    ```bash
    # Edit ~/.codex/config.toml to set preferences
    # Example:
-   # model = "gpt-5.2-codex"
+   # model = "gpt-5.6-sol"
    # model_reasoning_effort = "medium"
    ```
 
@@ -271,7 +276,7 @@ if (conversationIdMatch) {
 ## Performance Optimizations
 
 ### Smart Model Selection
-- **Default to gpt-5.2-codex**: Optimal for agentic coding without configuration
+- **Default to gpt-5.6-sol**: Optimal for agentic coding without configuration
 - **Context-Aware Suggestions**: Better model recommendations based on task type
 - **Consistent Experience**: Same model across session interactions
 
@@ -319,7 +324,7 @@ if (conversationIdMatch) {
    - Verify: Check `CODEX_HOME/auth.json` exists
 
 2. **Model Not Available**
-   - Solution: Use default `gpt-5.2-codex` or try alternative models
+   - Solution: Use default `gpt-5.6-sol` or try alternative models
    - Check: Codex CLI documentation for available models
 
 3. **Resume Functionality Not Working**

--- a/docs/session-management.md
+++ b/docs/session-management.md
@@ -43,7 +43,7 @@ interface ConversationTurn {
 #### Enhanced Codex Tool
 - **sessionId** (optional): Session ID for conversational context
 - **resetSession** (optional): Reset session history before processing
-- **model** (optional): Model selection (defaults to `gpt-5.2-codex`)
+- **model** (optional): Model selection (defaults to `gpt-5.6-sol`)
 - **reasoningEffort** (optional): Control reasoning depth (low/medium/high)
 - **Smart context building**: Uses native resume or fallback context
 - **Robust error handling**: Graceful degradation for various failure modes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-mcp-server",
-  "version": "1.4.10",
+  "version": "1.4.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-mcp-server",
-      "version": "1.4.10",
+      "version": "1.4.11",
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.24.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-mcp-server",
-  "version": "1.4.10",
+  "version": "1.4.11",
   "description": "MCP server wrapper for OpenAI Codex CLI",
   "main": "dist/index.js",
   "bin": {

--- a/src/__tests__/context-building.test.ts
+++ b/src/__tests__/context-building.test.ts
@@ -61,7 +61,7 @@ describe('Context Building Analysis', () => {
 
     // Check what prompt was sent to Codex - should be enhanced but not conversational
     const call = mockedExecuteCommand.mock.calls[0];
-    const sentPrompt = call?.[1]?.[4]; // After exec, --model, gpt-5.3-codex, --skip-git-repo-check, prompt
+    const sentPrompt = call?.[1]?.[4]; // After exec, --model, gpt-5.6-sol, --skip-git-repo-check, prompt
     expect(sentPrompt).toContain('Previous code context:');
     expect(sentPrompt).toContain('Task: Make it more efficient');
     expect(sentPrompt).not.toContain('Previous: What is recursion?'); // No conversational format

--- a/src/__tests__/default-model.test.ts
+++ b/src/__tests__/default-model.test.ts
@@ -40,7 +40,7 @@ describe('Default Model Configuration', () => {
     delete process.env.CODEX_MCP_CALLBACK_URI;
   });
 
-  test('should use gpt-5.3-codex as default model when no model specified', async () => {
+  test('should use gpt-5.6-sol as default model when no model specified', async () => {
     await handler.execute({ prompt: 'Test prompt' });
 
     expect(mockedExecuteCommand).toHaveBeenCalledWith(
@@ -48,7 +48,7 @@ describe('Default Model Configuration', () => {
       [
         'exec',
         '--model',
-        'gpt-5.3-codex',
+        'gpt-5.6-sol',
         '--skip-git-repo-check',
         'Test prompt',
       ],
@@ -59,8 +59,8 @@ describe('Default Model Configuration', () => {
   test('should include default model in response metadata', async () => {
     const result = await handler.execute({ prompt: 'Test prompt' });
 
-    expect(result.content[0]._meta?.model).toBe('gpt-5.3-codex');
-    expect(result.structuredContent?.model).toBe('gpt-5.3-codex');
+    expect(result.content[0]._meta?.model).toBe('gpt-5.6-sol');
+    expect(result.structuredContent?.model).toBe('gpt-5.6-sol');
     expect(result._meta?.callbackUri).toBeUndefined();
   });
 
@@ -90,7 +90,7 @@ describe('Default Model Configuration', () => {
       [
         'exec',
         '--model',
-        'gpt-5.3-codex',
+        'gpt-5.6-sol',
         '--skip-git-repo-check',
         'Test prompt',
       ],
@@ -114,7 +114,7 @@ describe('Default Model Configuration', () => {
         'exec',
         '--skip-git-repo-check',
         '-c',
-        'model="gpt-5.3-codex"',
+        'model="gpt-5.6-sol"',
         'resume',
         'existing-conv-id',
         'Resume with default model',
@@ -134,7 +134,7 @@ describe('Default Model Configuration', () => {
       [
         'exec',
         '--model',
-        'gpt-5.3-codex',
+        'gpt-5.6-sol',
         '-c',
         'model_reasoning_effort="high"',
         '--skip-git-repo-check',

--- a/src/__tests__/edge-cases.test.ts
+++ b/src/__tests__/edge-cases.test.ts
@@ -133,7 +133,7 @@ describe('Edge Cases and Integration Issues', () => {
 
     // Should only use recent turns, not crash with too much context
     const call = mockedExecuteCommand.mock.calls[0];
-    const prompt = call?.[1]?.[4]; // After exec, --model, gpt-5.3-codex, --skip-git-repo-check, prompt
+    const prompt = call?.[1]?.[4]; // After exec, --model, gpt-5.6-sol, --skip-git-repo-check, prompt
     expect(typeof prompt).toBe('string');
     if (prompt) {
       expect(prompt.length).toBeLessThan(5000); // Reasonable limit

--- a/src/__tests__/error-scenarios.test.ts
+++ b/src/__tests__/error-scenarios.test.ts
@@ -157,7 +157,7 @@ describe('Error Handling Scenarios', () => {
     expect(result.content[0].text).toBe('Response');
     expect(mockedExecuteCommand).toHaveBeenCalledWith(
       'codex',
-      ['exec', '--model', 'gpt-5.3-codex', '--skip-git-repo-check', longPrompt],
+      ['exec', '--model', 'gpt-5.6-sol', '--skip-git-repo-check', longPrompt],
       expect.any(Object)
     );
   });

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -152,7 +152,7 @@ describe('Codex MCP Server', () => {
       const result = {
         content: [{ type: 'text', text: 'ok', _meta: { threadId: 'th_123' } }],
         structuredContent: { threadId: 'th_123' },
-        _meta: { model: 'gpt-5.3-codex' },
+        _meta: { model: 'gpt-5.6-sol' },
       };
 
       const parsed = CallToolResultSchema.safeParse(result);

--- a/src/__tests__/model-selection.test.ts
+++ b/src/__tests__/model-selection.test.ts
@@ -63,7 +63,7 @@ describe('Model Selection and Reasoning Effort', () => {
       [
         'exec',
         '--model',
-        'gpt-5.3-codex',
+        'gpt-5.6-sol',
         '-c',
         'model_reasoning_effort="high"',
         '--skip-git-repo-check',
@@ -141,7 +141,7 @@ describe('Model Selection and Reasoning Effort', () => {
       [
         'exec',
         '--model',
-        'gpt-5.3-codex',
+        'gpt-5.6-sol',
         '-c',
         'model_reasoning_effort="minimal"',
         '--skip-git-repo-check',
@@ -162,7 +162,7 @@ describe('Model Selection and Reasoning Effort', () => {
       [
         'exec',
         '--model',
-        'gpt-5.3-codex',
+        'gpt-5.6-sol',
         '-c',
         'model_reasoning_effort="none"',
         '--skip-git-repo-check',
@@ -183,7 +183,7 @@ describe('Model Selection and Reasoning Effort', () => {
       [
         'exec',
         '--model',
-        'gpt-5.3-codex',
+        'gpt-5.6-sol',
         '-c',
         'model_reasoning_effort="xhigh"',
         '--skip-git-repo-check',

--- a/src/__tests__/resume-functionality.test.ts
+++ b/src/__tests__/resume-functionality.test.ts
@@ -53,7 +53,7 @@ describe('Codex Resume Functionality', () => {
       [
         'exec',
         '--model',
-        'gpt-5.3-codex',
+        'gpt-5.6-sol',
         '--skip-git-repo-check',
         'First message',
       ],
@@ -166,7 +166,7 @@ describe('Codex Resume Functionality', () => {
         'exec',
         '--skip-git-repo-check',
         '-c',
-        'model="gpt-5.3-codex"',
+        'model="gpt-5.6-sol"',
         'resume',
         'existing-codex-session-id',
         'Continue the task',
@@ -196,7 +196,7 @@ describe('Codex Resume Functionality', () => {
       [
         'exec',
         '--model',
-        'gpt-5.3-codex',
+        'gpt-5.6-sol',
         '--skip-git-repo-check',
         'Reset and start new',
       ],
@@ -229,7 +229,7 @@ describe('Codex Resume Functionality', () => {
 
     // Should build enhanced prompt since no codex session ID
     const call = mockedExecuteCommand.mock.calls[0];
-    const sentPrompt = call?.[1]?.[4]; // After exec, --model, gpt-5.3-codex, --skip-git-repo-check, prompt
+    const sentPrompt = call?.[1]?.[4]; // After exec, --model, gpt-5.6-sol, --skip-git-repo-check, prompt
     expect(sentPrompt).toContain('Context:');
     expect(sentPrompt).toContain('Task: Follow up question');
   });

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,11 +13,15 @@ export const TOOLS = {
 export type ToolName = typeof TOOLS[keyof typeof TOOLS];
 
 // Codex model constants
-export const DEFAULT_CODEX_MODEL = 'gpt-5.3-codex' as const;
+export const DEFAULT_CODEX_MODEL = 'gpt-5.6-sol' as const;
 export const CODEX_DEFAULT_MODEL_ENV_VAR = 'CODEX_DEFAULT_MODEL' as const;
 
 // Available model options (for documentation/reference)
 export const AVAILABLE_CODEX_MODELS = [
+  'gpt-5.6-sol',
+  'gpt-5.6-terra',
+  'gpt-5.6-luna',
+  'gpt-5.6',
   'gpt-5.3-codex',
   'gpt-5.2-codex',
   'gpt-5.1-codex',


### PR DESCRIPTION
## Summary
Adds the GPT-5.6 model family to the codex/review tools and updates the default model from `gpt-5.3-codex` to `gpt-5.6-sol`, the GPT-5.6 flagship tier for reasoning and difficult coding tasks.

## Changes
- Add `gpt-5.6-sol` (flagship), `gpt-5.6-terra` (balanced), `gpt-5.6-luna` (high-throughput/lower-latency), and the `gpt-5.6` family alias to `AVAILABLE_CODEX_MODELS` in `src/types.ts`
- Change `DEFAULT_CODEX_MODEL` from `gpt-5.3-codex` to `gpt-5.6-sol`
- Update tests to expect the new default model
- Update `docs/api-reference.md`, `docs/codex-cli-integration.md`, `docs/session-management.md`, and `CLAUDE.md` to reflect the new model list and default
- Bump version to 1.4.11

Model slugs verified against codex-cli 0.146.0, which exposes `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`.

## Testing
- [x] Tests pass locally
- [x] New tests added (if applicable)

`npm test`: 10 suites, 76 tests, all passing. `npm run build`, `npm run lint`, and `npm run format:check` are clean.

## Related Issues



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for GPT-5.6 model options, including Sol, Terra, and Luna.
  * Updated the default model to GPT-5.6 Sol for standard and resumed sessions.

* **Documentation**
  * Updated model defaults, supported options, configuration guidance, performance notes, and troubleshooting examples.

* **Maintenance**
  * Incremented the package version to 1.4.11.
  * Updated validation coverage to reflect the new default model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->